### PR TITLE
Basic support for promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,6 @@ Options
 *  "mode": override the TEST_MODE environment variable.  In the absence of the TEST_MODE and this option, the mode defaults to "replay".
 *  "callbackSwap": allow an alternate function to monkey-patch the target function callbacks.  If the target function under test does not follow node convention of having a callback as it's last agument, you'll need to provide a custom function for this option.
 *  "argumentSerializer":  allow an alternate serialization to JSON.stringify on the target function arguments.  This is useful for deduplicating test data where you expect the arguments will be different for each call (perhaps with a timestamp or uuid) but do not require a unique response.
+*  "isPromise":  true indicates that the method easy-fix is wrapping returns a promise rather than using a callback function.
+
 

--- a/tests.js
+++ b/tests.js
@@ -6,31 +6,80 @@ const expect = require('chai').expect;
 const easyFix = require('./index');
 
 const ASYNC_DELAY = 1000;
-const thingToTest = {
-  state: 0,
-  incStateNextTick: (stateArg, callback) => {
-    thingToTest.state = stateArg.val;
-    process.nextTick(() => {
-      thingToTest.state += 1;
-      callback(null, thingToTest.state);
-    });
-  },
-  incStateAfterThreeSeconds: (stateArg, callback) => {
-    thingToTest.state = stateArg.val;
-    setTimeout(() => {
-      thingToTest.state += 1;
-      callback(null, thingToTest.state);
-    }, ASYNC_DELAY);
-  },
-  resetState: () => {
-    thingToTest.state = 0;
-  }
-};
 
-let easyFixStub;
-const runSharedTests = (expectTargetFnCalls) => {
+function createThingToTest() {
+    const thingToTest = {
+      state: 0,
+      incStateNextTick: (stateArg, callback) => {
+          thingToTest.state = stateArg.val;
+          process.nextTick(() => {
+          thingToTest.state += 1;
+          callback(null, thingToTest.state);
+          });
+      },
+      incStateAfterThreeSeconds: (stateArg, callback) => {
+          thingToTest.state = stateArg.val;
+          setTimeout(() => {
+          thingToTest.state += 1;
+          callback(null, thingToTest.state);
+          }, ASYNC_DELAY);
+      },
+      resetState: () => {
+          thingToTest.state = 0;
+      }
+    };
+
+    return thingToTest;
+}
+
+function wrapThing(mode, thing) {
+    const easyFixStub = easyFix.wrapAsyncMethod(thing, 'incStateNextTick', {
+      mode: mode,
+      sinon,
+      dir: 'tmp'
+    });
+
+    return easyFixStub;
+}
+
+function createPromiseGiverToTest() {
+  const thingToTest = {
+  state: 0,
+  incStateNextTick: (stateArg) => {
+      return new Promise(function(resolve, reject) {
+        thingToTest.state = stateArg.val;
+        process.nextTick(() => {
+          thingToTest.state += 1;
+          resolve(thingToTest.state);
+        });
+      });
+    },
+    resetState: () => {
+      thingToTest.state = 0;
+    }
+  };
+
+  return thingToTest;
+}
+
+function wrapPromiseGiver(mode, thing) {
+    const easyFixStub = easyFix.wrapAsyncMethod(thing, 'incStateNextTick', {
+      mode: mode,
+      isPromise: true,
+      sinon,
+      dir: 'tmp'
+    });
+
+    return easyFixStub;
+}
+
+
+const runSharedTests = (expectTargetFnCalls,mode) => {
 
   it('falls back onto wrapped method', (done) => {
+    const thingToTest = createThingToTest(); 
+    const easyFixStub = wrapThing(mode, thingToTest);
+
     thingToTest.incStateNextTick({ val: 0 }, (err, state) => {
       expect(state).to.equal(1);
       const expectedTargetState = expectTargetFnCalls ? 1 : 0;
@@ -41,6 +90,9 @@ const runSharedTests = (expectTargetFnCalls) => {
   });
 
   it('works with mulitple calls', (done) => {
+    const thingToTest = createThingToTest(); 
+    const easyFixStub = wrapThing(mode, thingToTest);
+
     thingToTest.incStateNextTick({ val: 0 }, (firstErr, firstState) => {
       thingToTest.incStateNextTick({ val: firstState }, (secondErr, secondState) => {
         expect(secondState).to.equal(2);
@@ -53,6 +105,9 @@ const runSharedTests = (expectTargetFnCalls) => {
   });
 
   it('works with circular references', (done) => {
+    const thingToTest = createThingToTest(); 
+    const easyFixStub = wrapThing(mode, thingToTest);
+
     const testObj = { val: 0 };
     testObj.circ = testObj;
     thingToTest.incStateNextTick(testObj, (err, state) => {
@@ -65,50 +120,75 @@ const runSharedTests = (expectTargetFnCalls) => {
   });
 };
 
-describe('wrapAsyncMethod (live mode)', () => {
-  beforeEach(() => {
-    thingToTest.resetState();
-    easyFixStub = easyFix.wrapAsyncMethod(thingToTest, 'incStateNextTick', {
-      mode: 'live',
-      sinon,
-      dir: 'tmp'
+const runSharedPromiseTests = (expectTargetFnCalls, mode) => {
+  
+  it('falls back onto wrapped method', (done) => {
+    const thingToTest = createPromiseGiverToTest(); 
+    const easyFixStub = wrapPromiseGiver(mode, thingToTest);
+
+    const incPromise = thingToTest.incStateNextTick({ val: 0 });
+    incPromise.then((state) => {
+      expect(state).to.equal(1);
+      const expectedTargetState = expectTargetFnCalls ? 1 : 0;
+      expect(thingToTest.state).to.equal(expectedTargetState);
+      expect(easyFixStub.callCount).to.equal(1);
+      done();
     });
   });
-  afterEach(() => {
-    easyFixStub.restore();
+
+  it('works with mulitple calls', (done) => {
+    const thingToTest = createPromiseGiverToTest(); 
+    const easyFixStub = wrapPromiseGiver(mode, thingToTest);
+
+
+    thingToTest.incStateNextTick({ val: 0 }).then((firstState) => {
+      thingToTest.incStateNextTick({ val: firstState }).then((secondState) => {
+        expect(secondState).to.equal(2);
+        const expectedTargetState = expectTargetFnCalls ? 2 : 0;
+        expect(thingToTest.state).to.equal(expectedTargetState);
+        expect(easyFixStub.callCount).to.equal(2);
+        done();
+      });
+    });
   });
 
-  runSharedTests(true);
+  it('works with circular references', (done) => {
+    const thingToTest = createPromiseGiverToTest(); 
+    const easyFixStub = wrapPromiseGiver(mode, thingToTest);
+
+    const testObj = { val: 0 };
+    testObj.circ = testObj;
+    thingToTest.incStateNextTick(testObj).then((state) => {
+      expect(state).to.equal(1);
+      const expectedTargetState = expectTargetFnCalls ? 1 : 0;
+      expect(thingToTest.state).to.equal(expectedTargetState);
+      expect(easyFixStub.callCount).to.equal(1);
+      done();
+    });
+  });
+
+};
+
+describe('wrapAsyncMethod (live mode)', () => {
+  runSharedTests(true, 'live');
 });
 
 describe('wrapAsyncMethod (capture mode)', () => {
-  beforeEach(() => {
-    thingToTest.resetState();
-    easyFixStub = easyFix.wrapAsyncMethod(thingToTest, 'incStateNextTick', {
-      mode: 'capture',
-      sinon,
-      dir: 'tmp'
-    });
-  });
-  afterEach(() => {
-    easyFixStub.restore();
-  });
-
-  runSharedTests(true);
+  runSharedTests(true, 'capture');
 });
 
 describe('wrapAsyncMethod (replay mode)', () => {
-  beforeEach(() => {
-    thingToTest.resetState();
-    easyFixStub = easyFix.wrapAsyncMethod(thingToTest, 'incStateNextTick', {
-      mode: 'replay',
-      sinon,
-      dir: 'tmp'
-    });
-  });
-  afterEach(() => {
-    easyFixStub.restore();
-  });
+  runSharedTests(false, 'replay');
+});
 
-  runSharedTests(false);
+describe('wrapAsyncMethod (promises in live mode)', () => {
+  runSharedPromiseTests(true, 'live');
+});
+
+describe('wrapAsyncMethod (promises in capture mode)', () => {
+  runSharedPromiseTests(true, 'capture');
+});
+
+describe('wrapAsyncMethod (promises in replay mode)', () => {
+  runSharedPromiseTests(false, 'replay');
 });


### PR DESCRIPTION
Basic wrapping for methods that return a promise
I had to change style of tests somewhat - shared instance of the wrapped object caused false failures on replay mode of the promise tests.

Hope it helps - I really like this library!  
- CT
