### PR TITLE
Include more information in error message when missing mocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,13 @@ const modes = {
 
 const HASH_LENGTH = 12;
 
-const niceErrMsg = 'This test (in replay mode) could not read the expected mock data.  If you have not already, try running this test in capture mode to generate new test fixtures.  If you continue to see this error, a likely cause is differing (frequently changing) argument for the wrapped asynchronous task.  This can be mitigated by defining an argumentSerializer option that ignores the frequently-changing argument.'; // eslint-disable-line max-len
+const NICE_ERR_HEADER = 'This test (in replay mode) could not read the expected mock data from'; // eslint-disable-line max-len
+const NICE_ERR_SERIALIZATION_DESCRIPTOR = 'Serialized arguments';
+const NICE_ERR_FOOTER = 'If you have not already, try running this test in capture mode to generate new test fixtures.  If you continue to see this error, a likely cause is differing (frequently changing) argument for the wrapped asynchronous task.  This can be mitigated by defining an argumentSerializer option that ignores the frequently-changing argument.'; // eslint-disable-line max-len
+
+const getNiceError = (file, details) => {
+  return `${NICE_ERR_HEADER} "${file}"\n\n${NICE_ERR_SERIALIZATION_DESCRIPTOR}:\n${details}\n\n${NICE_ERR_FOOTER}`; // eslint-disable-line max-len
+};
 
 /**
  * Safe JSON Serializer will not fail in the face of circular references
@@ -112,7 +118,7 @@ exports.wrapAsyncMethod = function (obj, method, optionsArg) {
     fs.readFile(responsePath, (err, cannedResponse) => {
       if (err) {
         if (err.code === 'ENOENT') {
-          throw new Error(niceErrMsg);
+          throw new Error(getNiceError(responsePath, argStr));
         }
         throw err;
       }

--- a/test-config.json
+++ b/test-config.json
@@ -1,0 +1,3 @@
+{
+  "testErrorMessage": "This test (in replay mode) could not read the expected mock data from \"tmp/incStateNextTick-c156c7373216-response.json\"\n\nSerialized arguments:\n[\n  {\n    \"foo\": \"bar\"\n  },\n  null\n]\n\nIf you have not already, try running this test in capture mode to generate new test fixtures.  If you continue to see this error, a likely cause is differing (frequently changing) argument for the wrapped asynchronous task.  This can be mitigated by defining an argumentSerializer option that ignores the frequently-changing argument."
+}


### PR DESCRIPTION
Currently if we can't find mocks for a method wrapped with easy-fix we get an error with no details on _which_ method was wrapped and _what_ the mismatching data is. This can make it difficult to debug, particularly when you have multi easy-fix calls within a single test.

This PR aims to augment the error message with:

1. The mock filename (which is derived from the method name by default)
2. The serialized argument data

While point 2 has the potential to create overly verbose error output I think it'll be worth it for the ease of debugging.

Sample output:

```
     Uncaught Error: This test (in replay mode) could not read the expected mock data from "tmp/incStateNextTick-c156c7373216-response.json"

Serialized arguments:
[
  {
    "foo": "bar"
  },
  null
]

If you have not already, try running this test in capture mode to generate new test fixtures.  If you continue to see this error, a likely cause is differing (frequently changing) argument for the wrapped asynchronous task.  This can be mitigated by defining an argumentSerializer option that ignores the frequently-changing argument.
```

Unfortunately to test this feature I had to use the deprecated domain API. I'm open to suggestions for avoid it but I'm not aware of any other means for catching an uncaught error.