### PR TITLE
wrapAsyncMethod broken when returnValue is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ exports.wrapAsyncMethod = function (obj, method, optionsArg) {
 
     if (options.mode === modes.capture) {
       let returnValue = originalFn.apply(self, callingArgs);
-      wrappedCallData.returnedPromise = !!returnValue.then;
+      wrappedCallData.returnedPromise = returnValue && !!returnValue.then;
       if (wrappedCallData.returnedPromise) {
         returnValue =
           returnValue


### PR DESCRIPTION
In the very common case of a non-promise async method which does not return anything, or one that happens to return null/undefined, wrapAsyncMethod's promise check breaks. The simple check is to precede the promise check with a non-null check.