### PR TITLE
Reinstate properties on errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,8 +209,11 @@ exports.wrapAsyncMethod = function (obj, method, optionsArg) {
         if (options.reinstantiateErrors &&
           cannedJson.calledBackWithError &&
           callbackArgs[0] instanceof Error === false) {
-          callbackArgs[0] = new Error(`${cannedJson.calledBackWithError.message} ${NOTE}`);
-          callbackArgs[0].stack = cannedJson.calledBackWithError.stack;
+          const err = new Error(`${cannedJson.calledBackWithError.message} ${NOTE}`);
+          // Errors may contain additional properties that we'll want to write back
+          Object.assign(err, callbackArgs[0]);
+          err.stack = cannedJson.calledBackWithError.stack;
+          callbackArgs[0] = err;
         }
         origCallback.apply(self, callbackArgs);
       });
@@ -226,9 +229,11 @@ exports.wrapAsyncMethod = function (obj, method, optionsArg) {
             if (options.reinstantiateErrors &&
               cannedJson.rejectedWithError &&
               promiseRejectionArgs[0] instanceof Error === false) {
-              promiseRejectionArgs[0] =
-                new Error(`${cannedJson.rejectedWithError.message} ${NOTE}`);
-              promiseRejectionArgs[0].stack = cannedJson.rejectedWithError.stack;
+              const err = new Error(`${cannedJson.rejectedWithError.message} ${NOTE}`);
+              // Errors may contain additional properties that we'll want to write back
+              Object.assign(err, promiseRejectionArgs[0]);
+              err.stack = cannedJson.rejectedWithError.stack;
+              promiseRejectionArgs[0] = err;
             }
             return reject.apply(self, promiseRejectionArgs);
           }

--- a/tests.js
+++ b/tests.js
@@ -20,6 +20,7 @@ const thingToTest = {
   causeAsyncError: (callback) => {
     process.nextTick(() => {
       const error = new Error(errorMessage);
+      error.otherProperty = 'blah';
       callback(error);
     });
     return expectedReturnValue;
@@ -36,7 +37,9 @@ const thingToTest = {
   promiseThatRejects: () => {
     return new Promise((resolve, reject) => {
       process.nextTick(() => {
-        reject(new Error(errorMessage));
+        const err = new Error(errorMessage);
+        err.otherProperty = 'blah';
+        reject(err);
       });
     });
   },
@@ -67,6 +70,14 @@ const runSharedTests = (expectTargetFnCalls) => {
       expect(foundReturnValue).to.equal(expectedReturnValue);
       expect(err instanceof Error).to.equal(true);
       expect(causeErrorStub.callCount).to.equal(1);
+      done();
+    });
+  });
+
+  it('additional properties are present on errors', (done) => {
+    thingToTest.causeAsyncError((err) => {
+      expect(err.stack).to.not.include('easy-fix/index.js');
+      expect(err.otherProperty).to.eql('blah');
       done();
     });
   });
@@ -125,6 +136,16 @@ const runSharedTests = (expectTargetFnCalls) => {
         validationError = caughtError;
       }
       done(validationError);
+    });
+  });
+
+  it('attaches correct stack and metadata to error', () => {
+    return thingToTest.promiseThatRejects()
+    .catch((err) => {
+      expect(err instanceof Error).to.equal(true);
+      expect(promiseRejectStub.callCount).to.equal(1);
+      expect(err.stack).to.not.include('easy-fix/index.js');
+      expect(err.otherProperty).to.eql('blah');
     });
   });
 


### PR DESCRIPTION
When reinstating errors, additional properties on those errors were not correctly preserved. Now they are.